### PR TITLE
Add functionality to print UNIX Epoch time

### DIFF
--- a/examples/Example7-Print_Epoch/Example7-Print_Epoch.ino
+++ b/examples/Example7-Print_Epoch/Example7-Print_Epoch.ino
@@ -1,0 +1,54 @@
+/*
+  Prints the UNIX Epoch time from the RV-8803 Real Time Clock
+  By: Andy England
+  SparkFun Electronics
+  Updated by: Adam Garbo
+  Date: 4/21/2020
+  License: This code is public domain but you buy me a beer if you use this and we meet someday (Beerware license).
+  Feel like supporting our work? Buy a board from SparkFun!
+  https://www.sparkfun.com/products/14642
+  This example shows how to print the time from the RTC.
+  Hardware Connections:
+    Plug the RTC into the Qwiic port on your microcontroller or on your Qwiic shield/adapter.
+    If you are using an adapter cable, here is the wire color scheme: 
+    Black=GND, Red=3.3V, Blue=SDA, Yellow=SCL
+    Open the serial monitor at 115200 baud
+*/
+
+#include <SparkFun_RV8803.h>
+
+RV8803 rtc;
+
+void setup() {
+
+  Wire.begin();
+
+  Serial.begin(115200);
+  Serial.println("Print UNIX Epoch Time Example");
+
+  if (rtc.begin() == false) {
+    Serial.println("Something went wrong, check wiring");
+  }
+  else
+  {
+    Serial.println("RTC online!");
+  }
+}
+
+void loop() {
+
+  if (rtc.updateTime() == false) //Updates the time variables from RTC
+  {
+    Serial.print("RTC failed to update");
+  }
+  
+  // Get the time in ISO 8601 format
+  String currentTime = rtc.stringTime8601();
+  Serial.println(currentTime);
+
+  // Get the UNIX Epoch time
+  unsigned long unixtime = rtc.getEpoch();
+  Serial.println(unixtime);
+
+  delay(1000);
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -43,6 +43,7 @@ getWeekday	        KEYWORD2
 getDate	            KEYWORD2
 getMonth	        KEYWORD2
 getYear	            KEYWORD2
+getEpoch	KEYWORD2
 
 getHundredthsCapture    KEYWORD2
 getSecondsCapture       KEYWORD2

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun Qwiic RTC RV8803 Arduino Library
-version=1.0.1
+version=1.0.2
 author=Andy England
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=A library to drive the RV-1805 extremely precise, extremely low power, real-time clock

--- a/src/SparkFun_RV8803.cpp
+++ b/src/SparkFun_RV8803.cpp
@@ -14,6 +14,7 @@ or concerns with licensing, please contact techsupport@sparkfun.com.
 Distributed as-is; no warranty is given.
 ******************************************************************************/
 
+#include <time.h>
 #include "SparkFun_RV8803.h"
 
 //****************************************************************************//

--- a/src/SparkFun_RV8803.cpp
+++ b/src/SparkFun_RV8803.cpp
@@ -189,6 +189,24 @@ char* RV8803::stringTime8601()
 	return(timeStamp);
 }
 
+//Returns time in UNIX Epoch time format
+uint32_t RV8803::getEpoch()
+{
+  struct tm tm;
+
+  tm.tm_isdst = -1;
+  tm.tm_yday = 0;
+  tm.tm_wday = 0;
+  tm.tm_year = BCDtoDEC(_time[TIME_YEAR]) + 100;
+  tm.tm_mon = BCDtoDEC(_time[TIME_MONTH]) - 1;
+  tm.tm_mday = BCDtoDEC(_time[TIME_DATE]);
+  tm.tm_hour = BCDtoDEC(_time[TIME_HOURS]);
+  tm.tm_min = BCDtoDEC(_time[TIME_MINUTES]);
+  tm.tm_sec = BCDtoDEC(_time[TIME_SECONDS]);
+
+  return mktime(&tm);
+}
+
 //
 bool RV8803::setTime(uint8_t sec, uint8_t min, uint8_t hour, uint8_t weekday, uint8_t date, uint8_t month, uint16_t year)
 {

--- a/src/SparkFun_RV8803.h
+++ b/src/SparkFun_RV8803.h
@@ -170,6 +170,7 @@ class RV8803
 	uint8_t getWeekday();
 	uint8_t getMonth();
 	uint16_t getYear();	
+	uint32_t getEpoch();
 	
 	uint8_t getHundredthsCapture();
 	uint8_t getSecondsCapture();


### PR DESCRIPTION
Hi Andy (@AndyEngland521 ),

Similar to the PR I made for the RV-1805 library, I've added functionality to print the UNIX Epoch time to the RV-8803 library. Tested with a SparkFun Artemis Redboard.

The getEpoch() function allows the user to print the current date and time as a UNIX Epoch timestamp. This requires including <time.h>. Example7-Print_Epoch demonstrates the use of this function.

I'll work on adding additional functionality to this library once I have a bit more hands-on time with it.

Cheers,
Adam