### PR TITLE
Add functionality to set date and time using UNIX Epoch time

### DIFF
--- a/examples/Example8-Set_Epoch/Example8-Set_Epoch.ino
+++ b/examples/Example8-Set_Epoch/Example8-Set_Epoch.ino
@@ -1,0 +1,57 @@
+/*
+  Set the RV-8803 Real Time Clock using UNIX Epoch time
+  By: Andy England
+  SparkFun Electronics
+  Updated by: Adam Garbo
+  Date: 4/25/2020
+  License: This code is public domain but you buy me a beer if you use this and we meet someday (Beerware license).
+  Feel like supporting our work? Buy a board from SparkFun!
+  https://www.sparkfun.com/products/14642
+  This example shows how to print the time from the RTC.
+  Hardware Connections:
+    Plug the RTC into the Qwiic port on your microcontroller or on your Qwiic shield/adapter.
+    If you are using an adapter cable, here is the wire color scheme: 
+    Black=GND, Red=3.3V, Blue=SDA, Yellow=SCL
+    Open the serial monitor at 115200 baud
+*/
+
+#include <SparkFun_RV8803.h>
+
+RV8803 rtc;
+
+void setup() {
+
+  Wire.begin();
+
+  Serial.begin(115200);
+  Serial.println("Set UNIX Epoch Time Example");
+
+  if (rtc.begin() == false) {
+    Serial.println("Something went wrong, check wiring");
+  }
+  else
+  {
+    Serial.println("RTC online!");
+  }
+
+  // Set the RTC time using UNIX Epoch time 
+  rtc.setEpoch(1609416000); // E.g. Thursday, December 31, 2020 12:00:00
+}
+
+void loop() {
+
+  if (rtc.updateTime() == false) //Updates the time variables from RTC
+  {
+    Serial.print("RTC failed to update");
+  }
+
+  // Print the current UNIX Epoch time
+  unsigned long unixtime = rtc.getEpoch();
+  Serial.println(unixtime);
+
+  // Confirm the date and time using the ISO 8601 timestamp
+  String currentTime = rtc.stringTime8601();
+  Serial.println(currentTime);
+
+  delay(1000);
+}

--- a/examples/Example8-Set_Epoch/Example8-Set_Epoch.ino
+++ b/examples/Example8-Set_Epoch/Example8-Set_Epoch.ino
@@ -40,7 +40,7 @@ void setup() {
 
 void loop() {
 
-  if (rtc.updateTime() == false) //Updates the time variables from RTC
+  if (rtc.updateTime() == false) // Updates the time variables from RTC
   {
     Serial.print("RTC failed to update");
   }

--- a/keywords.txt
+++ b/keywords.txt
@@ -4,105 +4,106 @@
 # Class
 ###################################################################
 
-RV8803      	    KEYWORD1
+RV8803	KEYWORD1
 
 ###################################################################
 # Methods and Functions
 ###################################################################
 
-begin	            KEYWORD2
+begin	KEYWORD2
 
-set12Hour           KEYWORD2
-set24Hour           KEYWORD2
-is12Hour            KEYWORD2
-isPM                KEYWORD2
+set12Hour 	KEYWORD2
+set24Hour	KEYWORD2
+is12Hour	KEYWORD2
+isPM	KEYWORD2
 
 stringDateUSA	KEYWORD2
 stringDate	KEYWORD2
 stringTime	KEYWORD2
 stringTimeStamp	KEYWORD2
-stringTime8601  KEYWORD2
+stringTime8601	KEYWORD2
 
-setTime	            KEYWORD2
+setTime	KEYWORD2
 setHundredthsToZero	KEYWORD2
-setSeconds  	    KEYWORD2
-setMinutes  	    KEYWORD2
-setHours	        KEYWORD2
-setWeekday  	    KEYWORD2
-setDate     	    KEYWORD2
-setMonth	        KEYWORD2
-setYear	            KEYWORD2
+setSeconds	KEYWORD2
+setMinutes	KEYWORD2
+setHours	KEYWORD2
+setWeekday	KEYWORD2
+setDate	KEYWORD2
+setMonth	KEYWORD2
+setYear	KEYWORD2
+setEpoch	KEYWORD2
 
-updateTime	        KEYWORD2
+updateTime	KEYWORD2
 
-getHundredths	    KEYWORD2
-getSeconds	        KEYWORD2
-getMinutes	        KEYWORD2
-getHours	        KEYWORD2
-getWeekday	        KEYWORD2
-getDate	            KEYWORD2
-getMonth	        KEYWORD2
-getYear	            KEYWORD2
+getHundredths	KEYWORD2
+getSeconds	KEYWORD2
+getMinutes	KEYWORD2
+getHours	KEYWORD2
+getWeekday	KEYWORD2
+getDate	KEYWORD2
+getMonth	KEYWORD2
+getYear	KEYWORD2
 getEpoch	KEYWORD2
 
-getHundredthsCapture    KEYWORD2
-getSecondsCapture       KEYWORD2
+getHundredthsCapture	KEYWORD2
+getSecondsCapture	KEYWORD2
 
 setToCompilerTime	KEYWORD2
 
-setCalibrationOffset    KEYWORD2
-getCalibrationOffset    KEYWORD2
+setCalibrationOffset	KEYWORD2
+getCalibrationOffset	KEYWORD2
 
 
-setEVICalibration   KEYWORD2
-setEVIDebounceTime   KEYWORD2
-setEVIEdgeDetection   KEYWORD2
-setEVIEventCapture   KEYWORD2
+setEVICalibration	KEYWORD2
+setEVIDebounceTime	KEYWORD2
+setEVIEdgeDetection	KEYWORD2
+setEVIEventCapture	KEYWORD2
 
-getEVICalibration   KEYWORD2
-uint8_t getEVIDebounceTime   KEYWORD2
-getEVIEdgeDetection   KEYWORD2
-getEVIEventCapture   KEYWORD2
-	
-setCountdownTimerEnable   KEYWORD2
-setCountdownTimerClockTicks   KEYWORD2
-setCountdownTimerFrequency   KEYWORD2
+getEVICalibration	KEYWORD2
+uint8_t getEVIDebounceTime	KEYWORD2
+getEVIEdgeDetection	KEYWORD2
+getEVIEventCapture	KEYWORD2
 
-setClockOutTimerFrequency   KEYWORD2
-getClockOutTimerFrequency   KEYWORD2
-		
-getCountdownTimerEnable   KEYWORD2
-getCountdownTimerClockTicks   KEYWORD2
-getCountdownTimerFrequency   KEYWORD2
-	
-setPeriodicTimeUpdateFrequency   KEYWORD2
-getPeriodicTimeUpdateFrequency   KEYWORD2
-	
-setItemsToMatchForAlarm   KEYWORD2
-setAlarmMinute   KEYWORD2
-setAlarmHour   KEYWORD2
-setAlarmWeekday   KEYWORD2
-setAlarmDate   KEYWORD2
-	
-uint8_t getAlarmMinute   KEYWORD2
-uint8_t getAlarmHour   KEYWORD2
-uint8_t getAlarmWeekday   KEYWORD2
-uint8_t getAlarmDate   KEYWORD2
+setCountdownTimerEnable	KEYWORD2
+setCountdownTimerClockTicks	KEYWORD2
+setCountdownTimerFrequency	KEYWORD2
 
-enableHardwareInterrupt   KEYWORD2
-disableHardwareInterrupt   KEYWORD2
-disableAllInterrupts   KEYWORD2
-	
-getInterruptFlag   KEYWORD2
-clearInterruptFlag   KEYWORD2
-clearAllInterruptFlags   KEYWORD2
-		
+setClockOutTimerFrequency	KEYWORD2
+getClockOutTimerFrequency	KEYWORD2
+
+getCountdownTimerEnable	KEYWORD2
+getCountdownTimerClockTicks	KEYWORD2
+getCountdownTimerFrequency	KEYWORD2
+
+setPeriodicTimeUpdateFrequency	KEYWORD2
+getPeriodicTimeUpdateFrequency	KEYWORD2
+
+setItemsToMatchForAlarm	KEYWORD2
+setAlarmMinute	KEYWORD2
+setAlarmHour	KEYWORD2
+setAlarmWeekday	KEYWORD2
+setAlarmDate 	KEYWORD2
+
+uint8_t getAlarmMinute	KEYWORD2
+uint8_t getAlarmHour	KEYWORD2
+uint8_t getAlarmWeekday	KEYWORD2
+uint8_t getAlarmDate	KEYWORD2
+
+enableHardwareInterrupt	KEYWORD2
+disableHardwareInterrupt	KEYWORD2
+disableAllInterrupts	KEYWORD2
+
+getInterruptFlag	KEYWORD2
+clearInterruptFlag	KEYWORD2
+clearAllInterruptFlags	KEYWORD2
+
 BCDtoDEC	KEYWORD2
 DECtoBCD	KEYWORD2
 
-readBit         KEYWORD2
-readTwoBits     KEYWORD2
-writeBit        KEYWORD2
+readBit	KEYWORD2
+readTwoBits	KEYWORD2
+writeBit	KEYWORD2
 readRegister	KEYWORD2
 writeRegister	KEYWORD2
 readMultipleRegisters	KEYWORD2
@@ -111,7 +112,7 @@ writeMultipleRegisters	KEYWORD2
 ###################################################################
 # Constants
 ###################################################################
-ALARM_ENABLE                        LITERAL1
+ALARM_ENABLE						LITERAL1
 EXTENSION_TEST						LITERAL1
 EXTENSION_WADA						LITERAL1
 EXTENSION_USEL						LITERAL1

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun Qwiic RTC RV8803 Arduino Library
-version=1.0.3
+version=1.0.4
 author=Andy England
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=A library to drive the RV-1805 extremely precise, extremely low power, real-time clock

--- a/src/SparkFun_RV8803.cpp
+++ b/src/SparkFun_RV8803.cpp
@@ -212,7 +212,7 @@ uint32_t RV8803::getEpoch()
 bool RV8803::setEpoch(uint32_t value)
 {
 	if (value < 946684800) {
-		value = 946684800;
+		value = 946684800; // 2000-01-01 00:00:00
 	}
 
 	struct tm tm;

--- a/src/SparkFun_RV8803.h
+++ b/src/SparkFun_RV8803.h
@@ -151,6 +151,7 @@ class RV8803
 		
 	bool setTime(uint8_t sec, uint8_t min, uint8_t hour, uint8_t weekday, uint8_t date, uint8_t month, uint16_t year);
 	bool setTime(uint8_t * time, uint8_t len);
+	bool setEpoch(uint32_t value);
 	bool setHundredthsToZero();
 	bool setSeconds(uint8_t value);
 	bool setMinutes(uint8_t value);
@@ -159,6 +160,7 @@ class RV8803
 	bool setWeekday(uint8_t value);
 	bool setMonth(uint8_t value);
 	bool setYear(uint16_t value);
+
 	
 	bool updateTime(); //Update the local array with the RTC registers
 


### PR DESCRIPTION
Hi Andy (@AndyEngland521 ),

Another minor update to the RV8803.

The setEpoch() function allows the user to set the current date and time using a UNIX Epoch timestamp. Example8-Set_Epoch demonstrates the use of this function. Tested with a SparkFun Artemis Redboard.

Also cleaned up keywords.txt spacings.

Cheers,
Adam