### PR TITLE
Add missing functions to read alarm registers

### DIFF
--- a/examples/Example4A-Alarm_Interrupt/Example4A-Alarm_Interrupt.ino
+++ b/examples/Example4A-Alarm_Interrupt/Example4A-Alarm_Interrupt.ino
@@ -49,8 +49,8 @@ void setup() {
   rtc.disableAllInterrupts();
   rtc.clearAllInterruptFlags();//Clear all flags in case any interrupts have occurred.
   rtc.setItemsToMatchForAlarm(MINUTE_ALARM_ENABLE, HOUR_ALARM_ENABLE, WEEKDAY_ALARM_ENABLE, DATE_ALARM_ENABLE); //The alarm interrupt compares the alarm interrupt registers with the current time registers. We must choose which registers we want to compare by setting bits to true or false
-  rtc.setAlarmMinute(minuteAlarmValue);
-  rtc.setAlarmHour(hourAlarmValue);
+  rtc.setAlarmMinutes(minuteAlarmValue);
+  rtc.setAlarmHours(hourAlarmValue);
   rtc.setAlarmWeekday(weekdayAlarmValue);
   //rtc.setAlarmDate(dateAlarmValue); //Uncomment this line if you are using the date alarm instead of the weekday alarm.
   rtc.enableHardwareInterrupt(ALARM_INTERRUPT); 

--- a/keywords.txt
+++ b/keywords.txt
@@ -12,7 +12,7 @@ RV8803	KEYWORD1
 
 begin	KEYWORD2
 
-set12Hour 	KEYWORD2
+set12Hour	KEYWORD2
 set24Hour	KEYWORD2
 is12Hour	KEYWORD2
 isPM	KEYWORD2
@@ -80,13 +80,13 @@ setPeriodicTimeUpdateFrequency	KEYWORD2
 getPeriodicTimeUpdateFrequency	KEYWORD2
 
 setItemsToMatchForAlarm	KEYWORD2
-setAlarmMinute	KEYWORD2
-setAlarmHour	KEYWORD2
+setAlarmMinutes	KEYWORD2
+setAlarmHours	KEYWORD2
 setAlarmWeekday	KEYWORD2
-setAlarmDate 	KEYWORD2
+setAlarmDate	KEYWORD2
 
-uint8_t getAlarmMinute	KEYWORD2
-uint8_t getAlarmHour	KEYWORD2
+uint8_t getAlarmMinutes	KEYWORD2
+uint8_t getAlarmHours	KEYWORD2
 uint8_t getAlarmWeekday	KEYWORD2
 uint8_t getAlarmDate	KEYWORD2
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun Qwiic RTC RV8803 Arduino Library
-version=1.1.1
+version=1.1.2
 author=Andy England
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=A library to drive the RV-1805 extremely precise, extremely low power, real-time clock

--- a/src/SparkFun_RV8803.cpp
+++ b/src/SparkFun_RV8803.cpp
@@ -549,7 +549,7 @@ void RV8803::setItemsToMatchForAlarm(bool minuteAlarm, bool hourAlarm, bool week
 	}
 }
 
-bool RV8803::setAlarmMinute(uint8_t minute)
+bool RV8803::setAlarmMinutes(uint8_t minute)
 {
 	uint8_t value = readRegister(RV8803_MINUTES_ALARM);
 	value &= (1 << ALARM_ENABLE); //clear everything but enable bit
@@ -557,7 +557,7 @@ bool RV8803::setAlarmMinute(uint8_t minute)
 	return writeRegister(RV8803_MINUTES_ALARM, value);
 }
 
-bool RV8803::setAlarmHour(uint8_t hour)
+bool RV8803::setAlarmHours(uint8_t hour)
 {
 	uint8_t value = readRegister(RV8803_HOURS_ALARM);
 	value &= (1 << ALARM_ENABLE); //clear everything but enable bit
@@ -580,6 +580,29 @@ bool RV8803::setAlarmDate(uint8_t date)
 	value &= (1 << ALARM_ENABLE); //clear everything but enable bit
 	value |= DECtoBCD(date);
 	return writeRegister(RV8803_WEEKDAYS_DATE_ALARM, value);
+}
+
+
+uint8_t RV8803::getAlarmMinutes()
+{
+	return BCDtoDEC(readRegister(RV8803_MINUTES_ALARM));
+}
+
+
+uint8_t RV8803::getAlarmHours()
+{
+	return BCDtoDEC(readRegister(RV8803_HOURS_ALARM));
+}
+
+
+uint8_t RV8803::getAlarmWeekday()
+{
+	return BCDtoDEC(readRegister(RV8803_WEEKDAYS_DATE_ALARM));
+}
+
+uint8_t RV8803::getAlarmDate()
+{
+	return BCDtoDEC(readRegister(RV8803_WEEKDAYS_DATE_ALARM));
 }
 
 /*********************************
@@ -658,7 +681,8 @@ bool RV8803::writeBit(uint8_t regAddr, uint8_t bitAddr, bool bitToWrite)
 	value |= bitToWrite << bitAddr;
 	return writeRegister(regAddr, value);
 }
-bool RV8803::writeBit(uint8_t regAddr, uint8_t bitAddr, uint8_t bitToWrite) //If we seean unsigned eight bit, we know we have to write two bits.
+
+bool RV8803::writeBit(uint8_t regAddr, uint8_t bitAddr, uint8_t bitToWrite) //If we see an unsigned 8-bit, we know we have to write two bits.
 {
 	uint8_t value = readRegister(regAddr);
 	value &= ~(3 << bitAddr);

--- a/src/SparkFun_RV8803.cpp
+++ b/src/SparkFun_RV8803.cpp
@@ -76,9 +76,9 @@ bool RV8803::begin(TwoWire &wirePort)
 	
 	_i2cPort->beginTransmission(RV8803_ADDR);
 	
-    if (_i2cPort->endTransmission() != 0)
+	if (_i2cPort->endTransmission() != 0)
 	{
-      return (false); //Error: Sensor did not ack
+		return (false); //Error: Sensor did not ack
 	}
 	return(true);
 }
@@ -696,12 +696,12 @@ uint8_t RV8803::readRegister(uint8_t addr)
 	_i2cPort->write(addr);
 	_i2cPort->endTransmission();
 
-    //typecasting the 1 parameter in requestFrom so that the compiler
-    //doesn't give us a warning about multiple candidates
-    if (_i2cPort->requestFrom(static_cast<uint8_t>(RV8803_ADDR), static_cast<uint8_t>(1)) != 0)
-    {
-        return _i2cPort->read();
-    }
+	//typecasting the 1 parameter in requestFrom so that the compiler
+	//doesn't give us a warning about multiple candidates
+	if (_i2cPort->requestFrom(static_cast<uint8_t>(RV8803_ADDR), static_cast<uint8_t>(1)) != 0)
+	{
+		return _i2cPort->read();
+	}
 	return false;
 }
 
@@ -710,8 +710,8 @@ bool RV8803::writeRegister(uint8_t addr, uint8_t val)
 	_i2cPort->beginTransmission(RV8803_ADDR);
 	_i2cPort->write(addr);
 	_i2cPort->write(val);
-    if (_i2cPort->endTransmission() != 0)
-      return (false); //Error: Sensor did not ack
+	if (_i2cPort->endTransmission() != 0)
+		return (false); //Error: Sensor did not ack
 	return(true);
 }
 
@@ -724,8 +724,8 @@ bool RV8803::writeMultipleRegisters(uint8_t addr, uint8_t * values, uint8_t len)
 		_i2cPort->write(values[i]);
 	}
 
-    if (_i2cPort->endTransmission() != 0)
-      return (false); //Error: Sensor did not ack
+	if (_i2cPort->endTransmission() != 0)
+		return (false); //Error: Sensor did not ack
 	return(true);
 }
 
@@ -733,8 +733,8 @@ bool RV8803::readMultipleRegisters(uint8_t addr, uint8_t * dest, uint8_t len)
 {
 	_i2cPort->beginTransmission(RV8803_ADDR);
 	_i2cPort->write(addr);
-    if (_i2cPort->endTransmission() != 0)
-      return (false); //Error: Sensor did not ack
+	if (_i2cPort->endTransmission() != 0)
+		return (false); //Error: Sensor did not ack
 
 	_i2cPort->requestFrom(static_cast<uint8_t>(RV8803_ADDR), len);
 	for (uint8_t i = 0; i < len; i++)

--- a/src/SparkFun_RV8803.h
+++ b/src/SparkFun_RV8803.h
@@ -46,12 +46,12 @@ Distributed as-is; no warranty is given.
 #define RV8803_MINUTES						0x12
 #define RV8803_HOURS						0x13
 #define RV8803_WEEKDAYS						0x14
-#define RV8803_DATE         				0x15
-#define RV8803_MONTHS        				0x16
-#define RV8803_YEARS        				0x17
-#define RV8803_MINUTES_ALARM     			0x18
-#define RV8803_HOURS_ALARM       			0x19
-#define RV8803_WEEKDAYS_DATE_ALARM   		0x1A
+#define RV8803_DATE							0x15
+#define RV8803_MONTHS						0x16
+#define RV8803_YEARS						0x17
+#define RV8803_MINUTES_ALARM				0x18
+#define RV8803_HOURS_ALARM					0x19
+#define RV8803_WEEKDAYS_DATE_ALARM			0x1A
 #define RV8803_TIMER_0						0x1B
 #define RV8803_TIMER_1						0x1C
 #define RV8803_EXTENSION					0x1D
@@ -127,14 +127,14 @@ Distributed as-is; no warranty is given.
 #define TIME_ARRAY_LENGTH 8 // Total number of writable values in device
 
 enum time_order {
-	TIME_HUNDREDTHS, // 0
-	TIME_SECONDS,    // 1
-	TIME_MINUTES,    // 2
-	TIME_HOURS,      // 3
-	TIME_WEEKDAY,	 // 4
-	TIME_DATE,       // 5
-	TIME_MONTH,      // 6
-	TIME_YEAR,       // 7
+	TIME_HUNDREDTHS,	// 0
+	TIME_SECONDS,		// 1
+	TIME_MINUTES,		// 2
+	TIME_HOURS,			// 3
+	TIME_WEEKDAY,		// 4
+	TIME_DATE,			// 5
+	TIME_MONTH,			// 6
+	TIME_YEAR,			// 7
 };
 
 class RV8803
@@ -168,7 +168,6 @@ class RV8803
 	bool setMonth(uint8_t value);
 	bool setYear(uint16_t value);
 
-	
 	bool updateTime(); //Update the local array with the RTC registers
 
 	uint8_t getHundredths();
@@ -214,13 +213,13 @@ class RV8803
 	bool getPeriodicTimeUpdateFrequency();
 	
 	void setItemsToMatchForAlarm(bool minuteAlarm, bool hourAlarm, bool weekdayAlarm, bool dateAlarm); //0 to 7, alarm goes off with match of second, minute, hour, etc
-	bool setAlarmMinute(uint8_t minute);
-	bool setAlarmHour(uint8_t hour);
+	bool setAlarmMinutes(uint8_t minute);
+	bool setAlarmHours(uint8_t hour);
 	bool setAlarmWeekday(uint8_t weekday);
 	bool setAlarmDate(uint8_t date);
 	
-	uint8_t getAlarmMinute();
-	uint8_t getAlarmHour();
+	uint8_t getAlarmMinutes();
+	uint8_t getAlarmHours();
 	uint8_t getAlarmWeekday();
 	uint8_t getAlarmDate();
 

--- a/src/SparkFun_RV8803.h
+++ b/src/SparkFun_RV8803.h
@@ -139,11 +139,11 @@ enum time_order {
 
 class RV8803
 {
-  public:
+public:
 	
-    RV8803( void );
+	RV8803( void );
 
-    bool begin(TwoWire &wirePort = Wire);
+	bool begin(TwoWire &wirePort = Wire);
 	
 	void set12Hour();
 	void set24Hour();
@@ -239,12 +239,12 @@ class RV8803
 	uint8_t readTwoBits(uint8_t regAddr, uint8_t bitAddr);
 	bool writeBit(uint8_t regAddr, uint8_t bitAddr, bool bitToWrite);
 	bool writeBit(uint8_t regAddr, uint8_t bitAddr, uint8_t bitToWrite);
-    uint8_t readRegister(uint8_t addr);
-    bool writeRegister(uint8_t addr, uint8_t val);
+	uint8_t readRegister(uint8_t addr);
+	bool writeRegister(uint8_t addr, uint8_t val);
 	bool readMultipleRegisters(uint8_t addr, uint8_t * dest, uint8_t len);
 	bool writeMultipleRegisters(uint8_t addr, uint8_t * values, uint8_t len);
 
-private:
+  private:
 	uint8_t _time[TIME_ARRAY_LENGTH];
 	bool _isTwelveHour = true;
 	TwoWire *_i2cPort;


### PR DESCRIPTION
Hi @AndyEngland521,

A couple of minor changes to the library, which addresses #14.

* Added missing functions to read alarm registers.
* Standardized names of `getAlarmMinutes()/Hours()` and `setAlarmMinutes()/Hours()` functions to match the `getMinutes()/Hours()` and `setMinutes()/Hours()` functions. This is the naming convention used in the the RV-1805 library and I think it's a good idea to maintain consistency between RTC libraries.
* Updated examples that made use of the above functions.
* Tidied up spacings.

Cheers,
Adam