### PR TITLE
Allow passing print buffer to string* functions

### DIFF
--- a/src/SparkFun_RV8803.cpp
+++ b/src/SparkFun_RV8803.cpp
@@ -115,51 +115,66 @@ bool RV8803::isPM()
 }
 
 //Returns the date in MM/DD/YYYY format.
+char* RV8803::stringDateUSA(char *buffer, size_t len)
+{
+	snprintf(buffer, len, "%02d/%02d/20%02d", BCDtoDEC(_time[TIME_MONTH]), BCDtoDEC(_time[TIME_DATE]), BCDtoDEC(_time[TIME_YEAR]));
+	return(buffer);
+}
+
+//Returns the date in MM/DD/YYYY format.
 char* RV8803::stringDateUSA()
 {
 	static char date[11]; //Max of mm/dd/yyyy with \0 terminator
-	sprintf(date, "%02d/%02d/20%02d", BCDtoDEC(_time[TIME_MONTH]), BCDtoDEC(_time[TIME_DATE]), BCDtoDEC(_time[TIME_YEAR]));
-	return(date);
+	return stringDateUSA(date, sizeof(date));
+}
+
+//Returns the date in the DD/MM/YYYY format.
+char*  RV8803::stringDate(char *buffer, size_t len)
+{
+	snprintf(buffer, len, "%02d/%02d/20%02d", BCDtoDEC(_time[TIME_DATE]), BCDtoDEC(_time[TIME_MONTH]), BCDtoDEC(_time[TIME_YEAR]));
+	return(buffer);
 }
 
 //Returns the date in the DD/MM/YYYY format.
 char*  RV8803::stringDate()
 {
 	static char date[11]; //Max of dd/mm/yyyy with \0 terminator
-	sprintf(date, "%02d/%02d/20%02d", BCDtoDEC(_time[TIME_DATE]), BCDtoDEC(_time[TIME_MONTH]), BCDtoDEC(_time[TIME_YEAR]));
-	return(date);
+	return stringDate(date, sizeof(date));
+}
+
+//Returns the time in hh:mm:ss (Adds AM/PM if in 12 hour mode).
+char* RV8803::stringTime(char *buffer, size_t len)
+{
+	if(is12Hour() == true)
+	{
+		char half = 'A';
+		uint8_t twelveHourCorrection = 0;
+		if(isPM())
+		{
+			half = 'P';
+			if (BCDtoDEC(_time[TIME_HOURS]) > 12)
+			{
+				twelveHourCorrection = 12;
+			}
+		}
+		snprintf(buffer, len, "%02d:%02d:%02d%cM", BCDtoDEC(_time[TIME_HOURS]) - twelveHourCorrection, BCDtoDEC(_time[TIME_MINUTES]), BCDtoDEC(_time[TIME_SECONDS]), half);
+	}
+	else
+	snprintf(buffer, len, "%02d:%02d:%02d", BCDtoDEC(_time[TIME_HOURS]), BCDtoDEC(_time[TIME_MINUTES]), BCDtoDEC(_time[TIME_SECONDS]));
+	
+	return(buffer);
 }
 
 //Returns the time in hh:mm:ss (Adds AM/PM if in 12 hour mode).
 char* RV8803::stringTime()
 {
-	static char time[11]; //Max of hh:mm:ssXM with \0 terminator
-
-	if(is12Hour() == true)
-	{
-		char half = 'A';
-		uint8_t twelveHourCorrection = 0;
-		if(isPM())
-		{
-			half = 'P';
-			if (BCDtoDEC(_time[TIME_HOURS]) > 12)
-			{
-				twelveHourCorrection = 12;
-			}
-		}
-		sprintf(time, "%02d:%02d:%02d%cM", BCDtoDEC(_time[TIME_HOURS]) - twelveHourCorrection, BCDtoDEC(_time[TIME_MINUTES]), BCDtoDEC(_time[TIME_SECONDS]), half);
-	}
-	else
-	sprintf(time, "%02d:%02d:%02d", BCDtoDEC(_time[TIME_HOURS]), BCDtoDEC(_time[TIME_MINUTES]), BCDtoDEC(_time[TIME_SECONDS]));
-	
-	return(time);
+	static char time[11];
+	return stringTime(time, sizeof(time));
 }
 
 //Returns the most recent timestamp captured on the EVI pin (if the EVI pin has been configured to capture events)
-char* RV8803::stringTimestamp()
+char* RV8803::stringTimestamp(char *buffer, size_t len)
 {
-	static char time[14]; //Max of hh:mm:ss:HHXM with \0 terminator
-
 	if(is12Hour() == true)
 	{
 		char half = 'A';
@@ -172,22 +187,31 @@ char* RV8803::stringTimestamp()
 				twelveHourCorrection = 12;
 			}
 		}
-		sprintf(time, "%02d:%02d:%02d:%02d%cM", BCDtoDEC(_time[TIME_HOURS]) - twelveHourCorrection, BCDtoDEC(_time[TIME_MINUTES]),  BCDtoDEC(readRegister(RV8803_SECONDS_CAPTURE)), BCDtoDEC(readRegister(RV8803_HUNDREDTHS_CAPTURE)), half);
+		snprintf(buffer, len, "%02d:%02d:%02d:%02d%cM", BCDtoDEC(_time[TIME_HOURS]) - twelveHourCorrection, BCDtoDEC(_time[TIME_MINUTES]),  BCDtoDEC(readRegister(RV8803_SECONDS_CAPTURE)), BCDtoDEC(readRegister(RV8803_HUNDREDTHS_CAPTURE)), half);
 	}
 	else
-	sprintf(time, "%02d:%02d:%02d:%02d", BCDtoDEC(_time[TIME_HOURS]), BCDtoDEC(_time[TIME_MINUTES]), BCDtoDEC(readRegister(RV8803_SECONDS_CAPTURE)), BCDtoDEC(readRegister(RV8803_HUNDREDTHS_CAPTURE)));
+	snprintf(buffer, len, "%02d:%02d:%02d:%02d", BCDtoDEC(_time[TIME_HOURS]), BCDtoDEC(_time[TIME_MINUTES]), BCDtoDEC(readRegister(RV8803_SECONDS_CAPTURE)), BCDtoDEC(readRegister(RV8803_HUNDREDTHS_CAPTURE)));
 	
-	return(time);
+	return(buffer);
+}
+
+char* RV8803::stringTimestamp()
+{
+	static char time[14]; //Max of hh:mm:ss:HHXM with \0 terminator
+	return stringTimestamp(time, sizeof(time));
 }
 
 //Returns timestamp in ISO 8601 format (yyyy-mm-ddThh:mm:ss).
+char* RV8803::stringTime8601(char *buffer, size_t len)
+{
+	snprintf(buffer, len, "20%02d-%02d-%02dT%02d:%02d:%02d", BCDtoDEC(_time[TIME_YEAR]), BCDtoDEC(_time[TIME_MONTH]), BCDtoDEC(_time[TIME_DATE]), BCDtoDEC(_time[TIME_HOURS]), BCDtoDEC(_time[TIME_MINUTES]), BCDtoDEC(_time[TIME_SECONDS]));
+	return(buffer);
+}
+
 char* RV8803::stringTime8601()
 {
 	static char timeStamp[21]; //Max of yyyy-mm-ddThh:mm:ss with \0 terminator
-
-	sprintf(timeStamp, "20%02d-%02d-%02dT%02d:%02d:%02d", BCDtoDEC(_time[TIME_YEAR]), BCDtoDEC(_time[TIME_MONTH]), BCDtoDEC(_time[TIME_DATE]), BCDtoDEC(_time[TIME_HOURS]), BCDtoDEC(_time[TIME_MINUTES]), BCDtoDEC(_time[TIME_SECONDS]));
-	
-	return(timeStamp);
+	return stringTime8601(timeStamp, sizeof(timeStamp));
 }
 
 //Returns time in UNIX Epoch time format

--- a/src/SparkFun_RV8803.h
+++ b/src/SparkFun_RV8803.h
@@ -150,10 +150,15 @@ public:
 	bool is12Hour(); //Returns true if 12hour bit is set
 	bool isPM(); //Returns true if is12Hour and PM bit is set
 
+	char* stringDateUSA(char *buffer, size_t len); //Return date in mm-dd-yyyy in supplied buffer
 	char* stringDateUSA(); //Return date in mm-dd-yyyy
+	char* stringDate(char *buffer, size_t len); //Return date in dd-mm-yyyy in supplied buffer
 	char* stringDate(); //Return date in dd-mm-yyyy
+	char* stringTime(char *buffer, size_t len);  //Return time hh:mm:ss with AM/PM if in 12 hour mode in supplied buffer
 	char* stringTime(); //Return time hh:mm:ss with AM/PM if in 12 hour mode
+	char* stringTimestamp(char *buffer, size_t len); //Return timestamp in hh:mm:ss:hh in supplied buffer, note that this must be read the same minute that the timestamp occurs or the minute will be wrong
 	char* stringTimestamp(); //Return timestamp in hh:mm:ss:hh, note that this must be read the same minute that the timestamp occurs or the minute will be wrong
+	char* stringTime8601(char *buffer, size_t len); //Return time in ISO 8601 format yyyy-mm-ddThh:mm:ss in supplied buffer
 	char* stringTime8601(); //Return time in ISO 8601 format yyyy-mm-ddThh:mm:ss
 		
 	bool setTime(uint8_t sec, uint8_t min, uint8_t hour, uint8_t weekday, uint8_t date, uint8_t month, uint16_t year);


### PR DESCRIPTION
Each of the string*() now have an alternative that accepts a buffer and length into which to print the formatted string.  It doesn't make the functions thread-safe but it does allow the caller to use their own buffer instead of the ones statically defined in the functions.   It also addresses the referenced issue since we're not passing a fixed length buffer to sprintf any more.

Fixes #20 