### PR TITLE
v1.2.2 - Correct confusion about Unix Epoch

### DIFF
--- a/examples/Example7-Print_Epoch/Example7-Print_Epoch.ino
+++ b/examples/Example7-Print_Epoch/Example7-Print_Epoch.ino
@@ -45,9 +45,15 @@ void loop()
     String currentTime = rtc.stringTime8601();
     Serial.println(currentTime);
 
+    // Get the Epoch time - starting from Jan 1st 2000
+    unsigned long epochTime = rtc.getEpoch();
+
     // Get the UNIX Epoch time
-    unsigned long unixtime = rtc.getEpoch();
-    Serial.println(unixtime);
+    // Unix time starts at Jan 1st 1970 UTC (not Jan 1st 2000)
+    // https://www.unixtimestamp.com/
+    //unsigned long epochTime = rtc.getEpoch(true); // <- Set the use1970sEpoch parameter to true (default is false)
+    
+    Serial.println(epochTime);
   }
   else
   {

--- a/examples/Example8-Set_Epoch/Example8-Set_Epoch.ino
+++ b/examples/Example8-Set_Epoch/Example8-Set_Epoch.ino
@@ -37,20 +37,27 @@ void setup()
     Serial.println("RTC online!");
   }
 
-  // Set the RTC time using UNIX Epoch time
-  rtc.setEpoch(1639007837); // E.g. https://www.epoch101.com/
+  // Set the RTC time to Thursday, December 31, 2020 12:00:00 (GMT / UTC)
+  rtc.setEpoch(662731200);
 
-  // Set the RTC time using UNIX 1970s Epoch time. This subtracts 946710000 from the value before sending to RTC.
-  //rtc.setEpoch(2585717837, true); // E.g. https://www.epoch101.com/
+  // Set the RTC time using UNIX 1970s Epoch time.
+  // This subtracts 946684800 from the value before sending to RTC.
+  //rtc.setEpoch(1609416000, true); // E.g. https://www.epoch101.com/
 }
 
 void loop()
 {
   if (rtc.updateTime() == true) //Updates the time variables from RTC
   {
-    // Print the current UNIX Epoch time
-    unsigned long unixtime = rtc.getEpoch();
-    Serial.println(unixtime);
+    // Print the current Epoch
+    unsigned long epochTime = rtc.getEpoch();
+
+    // Print the current UNIX Epoch
+    // Unix time starts at Jan 1st 1970 UTC (not Jan 1st 2000)
+    // https://www.unixtimestamp.com/
+    //unsigned long epochTime = rtc.getEpoch(true); // <- Set the use1970sEpoch parameter to true (default is false)
+
+    Serial.println(epochTime);
 
     // Confirm the date and time using the ISO 8601 timestamp
     String currentTime = rtc.stringTime8601();

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun Qwiic RTC RV8803 Arduino Library
-version=1.2.1
+version=1.2.2
 author=SparkFun Electronics <sparkfun.com>
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=A library to drive the RV-8803 extremely precise, extremely low power, real-time clock

--- a/src/SparkFun_RV8803.cpp
+++ b/src/SparkFun_RV8803.cpp
@@ -215,7 +215,7 @@ char* RV8803::stringTime8601()
 }
 
 //Returns time in UNIX Epoch time format
-uint32_t RV8803::getEpoch()
+uint32_t RV8803::getEpoch(bool use1970sEpoch)
 {
 	struct tm tm;
 
@@ -229,7 +229,16 @@ uint32_t RV8803::getEpoch()
 	tm.tm_min = BCDtoDEC(_time[TIME_MINUTES]);
 	tm.tm_sec = BCDtoDEC(_time[TIME_SECONDS]);
 
-  return mktime(&tm);
+	time_t t = mktime(&tm);
+
+	if(use1970sEpoch)
+	{
+	    // AVR GCC compiler sets the Epoch time to Jan 1st, 2000. We can 
+    	// increase the offset to Jan 1st, 1970 if folks want that format
+		t += 946684800;
+	}
+
+	return t;
 }
 
 //Sets time using UNIX Epoch time
@@ -239,7 +248,7 @@ bool RV8803::setEpoch(uint32_t value, bool use1970sEpoch)
 	{
 	    // AVR GCC compiler sets the Epoch time to Jan 1st, 2000. We can 
     	// reduce the offset from Jan 1st, 1970 if folks want that format
-		value -= 946710000;
+		value -= 946684800;
 	}
 
 	time_t t = value;

--- a/src/SparkFun_RV8803.h
+++ b/src/SparkFun_RV8803.h
@@ -183,7 +183,7 @@ public:
 	uint8_t getWeekday();
 	uint8_t getMonth();
 	uint16_t getYear();	
-	uint32_t getEpoch();
+	uint32_t getEpoch(bool use1970sEpoch = false);
 	
 	uint8_t getHundredthsCapture();
 	uint8_t getSecondsCapture();


### PR DESCRIPTION
Re-add use1970sEpoch as a parameter for getEpoch and implement it
Change setEpoch Unix offset to 946684800. (946710000 - the previous value - is Midnight Jan 1st 1970 GMT-7 (Boulder time))
Update examples 7 and 8 to be consistent. If you call setEpoch using the 1970 Epoch, you also need to call getEpoch using the 1970 Epoch.