### PR TITLE
Fix seconds skipping in updateTime()

### DIFF
--- a/src/SparkFun_RV8803.cpp
+++ b/src/SparkFun_RV8803.cpp
@@ -350,14 +350,14 @@ bool RV8803::updateTime()
 	if (readMultipleRegisters(RV8803_HUNDREDTHS, _time, TIME_ARRAY_LENGTH) == false)
 		return(false); //Something went wrong
 	
-	if (BCDtoDEC(_time[TIME_SECONDS]) == 59) //If seconds are at 59, read again to make sure we didn't accidentally skip a minute
+	if (BCDtoDEC(_time[TIME_HUNDREDTHS]) == 99 || BCDtoDEC(_time[TIME_SECONDS]) == 59) //If hundredths are at 99 or seconds are at 59, read again to make sure we didn't accidentally skip a second/minute
 	{	
 		uint8_t tempTime[TIME_ARRAY_LENGTH];
 		if (readMultipleRegisters(RV8803_HUNDREDTHS, tempTime, TIME_ARRAY_LENGTH) == false)
 		{
 			return(false); //Something went wrong
 		}
-		if (BCDtoDEC(tempTime[TIME_SECONDS]) == 0) //If the reading for seconds changed, then our new data is correct, otherwise, we can leave the old data.
+		if (BCDtoDEC(_time[TIME_HUNDREDTHS]) > BCDtoDEC(tempTime[TIME_HUNDREDTHS])) //If the reading for hundredths has rolled over, then our new data is correct, otherwise, we can leave the old data.
 		{
 			memcpy(_time, tempTime, TIME_ARRAY_LENGTH);
 		}


### PR DESCRIPTION
There is a bug when reading time to the hundredth resolution that will cause the time read to jitter a second.

This is visible if polling the RTC at a high rate (i.e. every 2-5ms) and will appear as the following:
```
RTC Time: 15:26:44.98 -> t_delta = 0.00s
RTC Time: 15:26:44.99 -> t_delta = 0.01s
RTC Time: 15:26:44.99 -> t_delta = 0.00s
RTC Time: 15:26:45.99 -> t_delta = 1.00s
RTC Time: 15:26:45.00 -> t_delta = -0.99s
RTC Time: 15:26:45.00 -> t_delta = 0.00s
RTC Time: 15:26:45.01-> t_delta = 0.01s
```

The reason for this is the exact same as the 59 second glitch on pg. 42 of the datasheet, but it is possible to trigger much more often.

With common I2C rates (100kHz+) you should only need to check for the hundredths changing, since consecutive reads should be 1ms (roughly) and change to the time must happen within two bytes being read (80us) for data to not appear corrupted.

However, once you drop to lower I2C rates (the spec goes to 0Hz...), it is possible to miss this glitch since it could take a few hundredths of a second to read out the entire line and hundredths could appear as 96/97/98 rather than 99. This could cause  missed minutes/hours/days/months/years. Obviously, this is a RTC, so we can assume some reasonable lower bound on frequency and that hundredths would not be relevant at this lower frequency.

To resolve this:

- I check for either hundredth being at 99 or seconds being at 59, and 
  - If either is true a 2nd reading is performed. 
  - I then check to see if the hundredths have rolled over (i.e. the 2nd hundredths is lower than the 1st)
    - If they have, then I copy the 2nd reading. 

This method should hold so long as a single reading takes less than a second (which is roughly at 100Hz I2C clock).

I know this method is not exactly what is described in the datasheet, however I found it to work more reliably at faster clock readings.

Thanks,
Nathan

