### PR TITLE
getEpoch() fix - for timezone offset issue

### DIFF
--- a/examples/Example8-Set_Epoch/Example8-Set_Epoch.ino
+++ b/examples/Example8-Set_Epoch/Example8-Set_Epoch.ino
@@ -11,12 +11,19 @@
 
   This example shows how to print the time from the RTC.
 
+  This example also illustrates how the epoch is applied differently on different platforms.
+  It shows how to use setEpoch on both older platforms (like AVR) and newer ones (like ESP32).
+  
+  Uncomment the "#define useAVR" if you are running this on an older board.
+
   Hardware Connections:
     Plug the RTC into the Qwiic port on your microcontroller or on your Qwiic shield/adapter.
     If you are using an adapter cable, here is the wire color scheme:
     Black=GND, Red=3.3V, Blue=SDA, Yellow=SCL
     Open the serial monitor at 115200 baud
 */
+
+//#define useAVR // Uncomment this line if you are running this on an older AVR-like board
 
 #include <SparkFun_RV8803.h> //Get the library here:http://librarymanager/All#SparkFun_RV-8803
 
@@ -25,6 +32,8 @@ RV8803 rtc;
 void setup()
 {
   Wire.begin();
+
+  delay(1000); // Delay for the ESP32
 
   Serial.begin(115200);
   Serial.println("Set UNIX Epoch Time Example");
@@ -37,12 +46,35 @@ void setup()
     Serial.println("RTC online!");
   }
 
+  rtc.setTimeZoneQuarterHours(0); // Make sure the time zone is zero, otherwise getEpoch will be offset
+
+  // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+#ifdef useAVR
+  // On older platforms like AVR (original SparkFun RedBoards and Arduino Uno):
+
   // Set the RTC time to Thursday, December 31, 2020 12:00:00 (GMT / UTC)
+  // The Unix Epoch UTC timestamp is 1609416000.
+
+  // Using the Year 2000 Epoch (as used by the AVR compiler and time library)
+  // The UTC epoch is: 662731200
   rtc.setEpoch(662731200);
 
-  // Set the RTC time using UNIX 1970s Epoch time.
+  // Set the RTC time using UNIX 1970s Epoch time. See e.g. https://www.epoch101.com/
   // This subtracts 946684800 from the value before sending to RTC.
-  //rtc.setEpoch(1609416000, true); // E.g. https://www.epoch101.com/
+  //rtc.setEpoch(1609416000, true);
+
+  // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+#else
+  // On newer platforms like ESP32 v2.0.5, the UNIX Epoch (1970s) is used automatically:
+
+  rtc.setEpoch(1609416000);
+
+#endif
+
+  // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
 }
 
 void loop()
@@ -50,12 +82,24 @@ void loop()
   if (rtc.updateTime() == true) //Updates the time variables from RTC
   {
     // Print the current Epoch
+
+    // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+#ifdef useAVR
+    // On older platforms like AVR (original SparkFun RedBoards and Arduino Uno):
+
+    unsigned long epochTime = rtc.getEpoch(true); // Use the UNIX Epoch (1970s)
+
+    // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+#else
+  // On newer platforms like ESP32 v2.0.5, the UNIX Epoch (1970s) is used automatically:
+
     unsigned long epochTime = rtc.getEpoch();
 
-    // Print the current UNIX Epoch
-    // Unix time starts at Jan 1st 1970 UTC (not Jan 1st 2000)
-    // https://www.unixtimestamp.com/
-    //unsigned long epochTime = rtc.getEpoch(true); // <- Set the use1970sEpoch parameter to true (default is false)
+#endif
+
+    // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
     Serial.println(epochTime);
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun Qwiic RTC RV8803 Arduino Library
-version=1.2.8
+version=1.2.9
 author=SparkFun Electronics <sparkfun.com>
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=A library to drive the RV-8803 extremely precise, extremely low power, real-time clock

--- a/src/SparkFun_RV8803.cpp
+++ b/src/SparkFun_RV8803.cpp
@@ -14,7 +14,6 @@ or concerns with licensing, please contact techsupport@sparkfun.com.
 Distributed as-is; no warranty is given.
 ******************************************************************************/
 
-#include <time.h>
 #include "SparkFun_RV8803.h"
 
 //****************************************************************************//

--- a/src/SparkFun_RV8803.cpp
+++ b/src/SparkFun_RV8803.cpp
@@ -62,140 +62,6 @@ Distributed as-is; no warranty is given.
 #define BUILD_SECOND ((BUILD_SECOND_0 * 10) + BUILD_SECOND_1)
 
 
-
-// When converting from a UTC based struct tm to a time_t value, you would normally use a utc
-// version of mktime - timegm(), but we don't have that on most micro controllers - so use 
-// the following. 
-
-///////////////////////////////////////////////////////////////////////////////////////////
-// Got this from: https://github.com/junhuanchen/esp32-PCF8563/blob/master/timegm.c
-
-/*
- * UTC version of mktime(3)
- */
-
-/*
- * This code is not portable, but works on most Unix-like systems.
- * If the local timezone has no summer time, using mktime(3) function
- * and adjusting offset would be usable (adjusting leap seconds
- * is still required, though), but the assumption is not always true.
- *
- * Anyway, no portable and correct implementation of UTC to time_t
- * conversion exists....
- */
-
-#define SFE_RV8803_EPOCH_YEAR      1970
-#define SFE_RV8803_TM_YEAR_BASE    1900
-
-static time_t
-sub_mkgmt(struct tm *tm)
-{
-    int y, nleapdays;
-    time_t t;
-    /* days before the month */
-    static const unsigned short moff[12] = {
-        0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334
-    };
-
-    /*
-     * XXX: This code assumes the given time to be normalized.
-     * Normalizing here is impossible in case the given time is a leap
-     * second but the local time library is ignorant of leap seconds.
-     */
-
-    /* minimal sanity checking not to access outside of the array */
-    if ((unsigned) tm->tm_mon >= 12)
-        return (time_t) -1;
-    if (tm->tm_year < SFE_RV8803_EPOCH_YEAR - SFE_RV8803_TM_YEAR_BASE)
-        return (time_t) -1;
-
-    y = tm->tm_year + SFE_RV8803_TM_YEAR_BASE - (tm->tm_mon < 2);
-    nleapdays = y / 4 - y / 100 + y / 400 -
-        ((SFE_RV8803_EPOCH_YEAR-1) / 4 - (SFE_RV8803_EPOCH_YEAR-1) / 100 + (SFE_RV8803_EPOCH_YEAR-1) / 400);
-    t = ((((time_t) (tm->tm_year - (SFE_RV8803_EPOCH_YEAR - SFE_RV8803_TM_YEAR_BASE)) * 365 +
-            moff[tm->tm_mon] + tm->tm_mday - 1 + nleapdays) * 24 +
-        tm->tm_hour) * 60 + tm->tm_min) * 60 + tm->tm_sec;
-
-    return (t < 0 ? (time_t) -1 : t);
-}
-
-time_t
-_timegm(struct tm *tm)
-{
-    time_t t, t2;
-    struct tm *tm2;
-    int sec;
-
-    /* Do the first guess. */
-    if ((t = sub_mkgmt(tm)) == (time_t) -1)
-        return (time_t) -1;
-
-    /* save value in case *tm is overwritten by gmtime() */
-    sec = tm->tm_sec;
-
-    tm2 = gmtime(&t);
-    if ((t2 = sub_mkgmt(tm2)) == (time_t) -1)
-        return (time_t) -1;
-
-    if (t2 < t || tm2->tm_sec != sec) {
-        /*
-         * Adjust for leap seconds.
-         *
-         *     real time_t time
-         *           |
-         *          tm
-         *         /    ... (a) first sub_mkgmt() conversion
-         *       t
-         *       |
-         *      tm2
-         *     /    ... (b) second sub_mkgmt() conversion
-         *   t2
-         *          --->time
-         */
-        /*
-         * Do the second guess, assuming (a) and (b) are almost equal.
-         */
-        t += t - t2;
-        tm2 = gmtime(&t);
-
-        /*
-         * Either (a) or (b), may include one or two extra
-         * leap seconds.  Try t, t + 2, t - 2, t + 1, and t - 1.
-         */
-        if (tm2->tm_sec == sec
-            || (t += 2, tm2 = gmtime(&t), tm2->tm_sec == sec)
-            || (t -= 4, tm2 = gmtime(&t), tm2->tm_sec == sec)
-            || (t += 3, tm2 = gmtime(&t), tm2->tm_sec == sec)
-            || (t -= 2, tm2 = gmtime(&t), tm2->tm_sec == sec))
-            ;   /* found */
-        else {
-            /*
-             * Not found.
-             */
-            if (sec >= 60)
-                /*
-                 * The given time is a leap second
-                 * (sec 60 or 61), but the time library
-                 * is ignorant of the leap second.
-                 */
-                ;   /* treat sec 60 as 59,
-                       sec 61 as 0 of the next minute */
-            else
-                /* The given time may not be normalized. */
-                t++;    /* restore t */
-        }
-    }
-
-    return (t < 0 ? (time_t) -1 : t);
-}
-
-///////////////////////////////////////////////////////////////////////////////////////////
-
-
-
-
-
-
 RV8803::RV8803(void)
 {
 }
@@ -1253,4 +1119,130 @@ int8_t RV8803::getTimeZoneQuarterHours(void)
     return signedUnsigned8.signed8; // Convert to int8_t - without ambiguity
 }
 
+
+// When converting from a UTC based struct tm to a time_t value, you would normally use a utc
+// version of mktime - timegm(), but we don't have that on most micro controllers - so use 
+// the following. 
+
+///////////////////////////////////////////////////////////////////////////////////////////
+// Got this from: https://github.com/junhuanchen/esp32-PCF8563/blob/master/timegm.c
+
+/*
+ * UTC version of mktime(3)
+ */
+
+/*
+ * This code is not portable, but works on most Unix-like systems.
+ * If the local timezone has no summer time, using mktime(3) function
+ * and adjusting offset would be usable (adjusting leap seconds
+ * is still required, though), but the assumption is not always true.
+ *
+ * Anyway, no portable and correct implementation of UTC to time_t
+ * conversion exists....
+ */
+
+#define SFE_RV8803_EPOCH_YEAR      1970
+#define SFE_RV8803_TM_YEAR_BASE    1900
+
+time_t RV8803::sub_mkgmt(struct tm *tm)
+{
+    int y, nleapdays;
+    time_t t;
+    /* days before the month */
+    static const unsigned short moff[12] = {
+        0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334
+    };
+
+    /*
+     * XXX: This code assumes the given time to be normalized.
+     * Normalizing here is impossible in case the given time is a leap
+     * second but the local time library is ignorant of leap seconds.
+     */
+
+    /* minimal sanity checking not to access outside of the array */
+    if ((unsigned) tm->tm_mon >= 12)
+        return (time_t) -1;
+    if (tm->tm_year < SFE_RV8803_EPOCH_YEAR - SFE_RV8803_TM_YEAR_BASE)
+        return (time_t) -1;
+
+    y = tm->tm_year + SFE_RV8803_TM_YEAR_BASE - (tm->tm_mon < 2);
+    nleapdays = y / 4 - y / 100 + y / 400 -
+        ((SFE_RV8803_EPOCH_YEAR-1) / 4 - (SFE_RV8803_EPOCH_YEAR-1) / 100 + (SFE_RV8803_EPOCH_YEAR-1) / 400);
+    t = ((((time_t) (tm->tm_year - (SFE_RV8803_EPOCH_YEAR - SFE_RV8803_TM_YEAR_BASE)) * 365 +
+            moff[tm->tm_mon] + tm->tm_mday - 1 + nleapdays) * 24 +
+        tm->tm_hour) * 60 + tm->tm_min) * 60 + tm->tm_sec;
+
+    return (t < 0 ? (time_t) -1 : t);
+}
+
+time_t RV8803::_timegm(struct tm *tm)
+{
+    time_t t, t2;
+    struct tm *tm2;
+    int sec;
+
+    /* Do the first guess. */
+    if ((t = sub_mkgmt(tm)) == (time_t) -1)
+        return (time_t) -1;
+
+    /* save value in case *tm is overwritten by gmtime() */
+    sec = tm->tm_sec;
+
+    tm2 = gmtime(&t);
+    if ((t2 = sub_mkgmt(tm2)) == (time_t) -1)
+        return (time_t) -1;
+
+    if (t2 < t || tm2->tm_sec != sec) {
+        /*
+         * Adjust for leap seconds.
+         *
+         *     real time_t time
+         *           |
+         *          tm
+         *         /    ... (a) first sub_mkgmt() conversion
+         *       t
+         *       |
+         *      tm2
+         *     /    ... (b) second sub_mkgmt() conversion
+         *   t2
+         *          --->time
+         */
+        /*
+         * Do the second guess, assuming (a) and (b) are almost equal.
+         */
+        t += t - t2;
+        tm2 = gmtime(&t);
+
+        /*
+         * Either (a) or (b), may include one or two extra
+         * leap seconds.  Try t, t + 2, t - 2, t + 1, and t - 1.
+         */
+        if (tm2->tm_sec == sec
+            || (t += 2, tm2 = gmtime(&t), tm2->tm_sec == sec)
+            || (t -= 4, tm2 = gmtime(&t), tm2->tm_sec == sec)
+            || (t += 3, tm2 = gmtime(&t), tm2->tm_sec == sec)
+            || (t -= 2, tm2 = gmtime(&t), tm2->tm_sec == sec))
+            ;   /* found */
+        else {
+            /*
+             * Not found.
+             */
+            if (sec >= 60)
+                /*
+                 * The given time is a leap second
+                 * (sec 60 or 61), but the time library
+                 * is ignorant of the leap second.
+                 */
+                ;   /* treat sec 60 as 59,
+                       sec 61 as 0 of the next minute */
+            else
+                /* The given time may not be normalized. */
+                t++;    /* restore t */
+        }
+    }
+
+    return (t < 0 ? (time_t) -1 : t);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/SparkFun_RV8803.cpp
+++ b/src/SparkFun_RV8803.cpp
@@ -84,8 +84,8 @@ Distributed as-is; no warranty is given.
  * conversion exists....
  */
 
-#define EPOCH_YEAR      1970
-#define TM_YEAR_BASE    1900
+#define SFE_RV8803_EPOCH_YEAR      1970
+#define SFE_RV8803_TM_YEAR_BASE    1900
 
 static time_t
 sub_mkgmt(struct tm *tm)
@@ -106,13 +106,13 @@ sub_mkgmt(struct tm *tm)
     /* minimal sanity checking not to access outside of the array */
     if ((unsigned) tm->tm_mon >= 12)
         return (time_t) -1;
-    if (tm->tm_year < EPOCH_YEAR - TM_YEAR_BASE)
+    if (tm->tm_year < SFE_RV8803_EPOCH_YEAR - SFE_RV8803_TM_YEAR_BASE)
         return (time_t) -1;
 
-    y = tm->tm_year + TM_YEAR_BASE - (tm->tm_mon < 2);
+    y = tm->tm_year + SFE_RV8803_TM_YEAR_BASE - (tm->tm_mon < 2);
     nleapdays = y / 4 - y / 100 + y / 400 -
-        ((EPOCH_YEAR-1) / 4 - (EPOCH_YEAR-1) / 100 + (EPOCH_YEAR-1) / 400);
-    t = ((((time_t) (tm->tm_year - (EPOCH_YEAR - TM_YEAR_BASE)) * 365 +
+        ((SFE_RV8803_EPOCH_YEAR-1) / 4 - (SFE_RV8803_EPOCH_YEAR-1) / 100 + (SFE_RV8803_EPOCH_YEAR-1) / 400);
+    t = ((((time_t) (tm->tm_year - (SFE_RV8803_EPOCH_YEAR - SFE_RV8803_TM_YEAR_BASE)) * 365 +
             moff[tm->tm_mon] + tm->tm_mday - 1 + nleapdays) * 24 +
         tm->tm_hour) * 60 + tm->tm_min) * 60 + tm->tm_sec;
 

--- a/src/SparkFun_RV8803.cpp
+++ b/src/SparkFun_RV8803.cpp
@@ -61,6 +61,141 @@ Distributed as-is; no warranty is given.
 #define BUILD_SECOND_1 (__TIME__[7] - 0x30)
 #define BUILD_SECOND ((BUILD_SECOND_0 * 10) + BUILD_SECOND_1)
 
+
+
+// When converting from a UTC based struct tm to a time_t value, you would normally use a utc
+// version of mktime - timegm(), but we don't have that on most micro controllers - so use 
+// the following. 
+
+///////////////////////////////////////////////////////////////////////////////////////////
+// Got this from: https://github.com/junhuanchen/esp32-PCF8563/blob/master/timegm.c
+
+/*
+ * UTC version of mktime(3)
+ */
+
+/*
+ * This code is not portable, but works on most Unix-like systems.
+ * If the local timezone has no summer time, using mktime(3) function
+ * and adjusting offset would be usable (adjusting leap seconds
+ * is still required, though), but the assumption is not always true.
+ *
+ * Anyway, no portable and correct implementation of UTC to time_t
+ * conversion exists....
+ */
+
+#define EPOCH_YEAR      1970
+#define TM_YEAR_BASE    1900
+
+static time_t
+sub_mkgmt(struct tm *tm)
+{
+    int y, nleapdays;
+    time_t t;
+    /* days before the month */
+    static const unsigned short moff[12] = {
+        0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334
+    };
+
+    /*
+     * XXX: This code assumes the given time to be normalized.
+     * Normalizing here is impossible in case the given time is a leap
+     * second but the local time library is ignorant of leap seconds.
+     */
+
+    /* minimal sanity checking not to access outside of the array */
+    if ((unsigned) tm->tm_mon >= 12)
+        return (time_t) -1;
+    if (tm->tm_year < EPOCH_YEAR - TM_YEAR_BASE)
+        return (time_t) -1;
+
+    y = tm->tm_year + TM_YEAR_BASE - (tm->tm_mon < 2);
+    nleapdays = y / 4 - y / 100 + y / 400 -
+        ((EPOCH_YEAR-1) / 4 - (EPOCH_YEAR-1) / 100 + (EPOCH_YEAR-1) / 400);
+    t = ((((time_t) (tm->tm_year - (EPOCH_YEAR - TM_YEAR_BASE)) * 365 +
+            moff[tm->tm_mon] + tm->tm_mday - 1 + nleapdays) * 24 +
+        tm->tm_hour) * 60 + tm->tm_min) * 60 + tm->tm_sec;
+
+    return (t < 0 ? (time_t) -1 : t);
+}
+
+time_t
+_timegm(struct tm *tm)
+{
+    time_t t, t2;
+    struct tm *tm2;
+    int sec;
+
+    /* Do the first guess. */
+    if ((t = sub_mkgmt(tm)) == (time_t) -1)
+        return (time_t) -1;
+
+    /* save value in case *tm is overwritten by gmtime() */
+    sec = tm->tm_sec;
+
+    tm2 = gmtime(&t);
+    if ((t2 = sub_mkgmt(tm2)) == (time_t) -1)
+        return (time_t) -1;
+
+    if (t2 < t || tm2->tm_sec != sec) {
+        /*
+         * Adjust for leap seconds.
+         *
+         *     real time_t time
+         *           |
+         *          tm
+         *         /    ... (a) first sub_mkgmt() conversion
+         *       t
+         *       |
+         *      tm2
+         *     /    ... (b) second sub_mkgmt() conversion
+         *   t2
+         *          --->time
+         */
+        /*
+         * Do the second guess, assuming (a) and (b) are almost equal.
+         */
+        t += t - t2;
+        tm2 = gmtime(&t);
+
+        /*
+         * Either (a) or (b), may include one or two extra
+         * leap seconds.  Try t, t + 2, t - 2, t + 1, and t - 1.
+         */
+        if (tm2->tm_sec == sec
+            || (t += 2, tm2 = gmtime(&t), tm2->tm_sec == sec)
+            || (t -= 4, tm2 = gmtime(&t), tm2->tm_sec == sec)
+            || (t += 3, tm2 = gmtime(&t), tm2->tm_sec == sec)
+            || (t -= 2, tm2 = gmtime(&t), tm2->tm_sec == sec))
+            ;   /* found */
+        else {
+            /*
+             * Not found.
+             */
+            if (sec >= 60)
+                /*
+                 * The given time is a leap second
+                 * (sec 60 or 61), but the time library
+                 * is ignorant of the leap second.
+                 */
+                ;   /* treat sec 60 as 59,
+                       sec 61 as 0 of the next minute */
+            else
+                /* The given time may not be normalized. */
+                t++;    /* restore t */
+        }
+    }
+
+    return (t < 0 ? (time_t) -1 : t);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+
+
+
+
+
+
 RV8803::RV8803(void)
 {
 }
@@ -465,13 +600,44 @@ char* RV8803::stringMonthShort()
 // Returns time in UNIX Epoch time format, adjusting for the time zone
 uint32_t RV8803::getEpoch(bool use1970sEpoch)
 {
-    uint32_t localEpoch = getLocalEpoch(use1970sEpoch);
 
+
+    // Okay, we need the non system timezone adjusted value in ticks.
+    // use our internal _timegm() method to do this. 
+
+    struct tm tm;
+
+    tm.tm_isdst = -1;
+    tm.tm_yday = 0;
+    tm.tm_wday = 0;
+    tm.tm_year = BCDtoDEC(_time[TIME_YEAR]) + 100;
+    tm.tm_mon = BCDtoDEC(_time[TIME_MONTH]) - 1;
+    tm.tm_mday = BCDtoDEC(_time[TIME_DATE]);
+    tm.tm_hour = BCDtoDEC(_time[TIME_HOURS]);
+    tm.tm_min = BCDtoDEC(_time[TIME_MINUTES]);
+    tm.tm_sec = BCDtoDEC(_time[TIME_SECONDS]);
+
+    // Call our internal version of timegm() (some systems don't have this)
+    // to get the value from our clock, without taking into the systems TimeZone.
+
+    time_t t = _timegm(&tm);
+
+    // If the user has added any timezone info, roll that in.
+
+    // see if the user set any timezone values
     int32_t tzOffset = (int32_t)getTimeZoneQuarterHours() * 15 * 60;
 
-    localEpoch -= tzOffset;
+    t -= tzOffset;
 
-    return localEpoch;
+
+    // For backward compatablity
+    if (use1970sEpoch) {
+        // AVR GCC compiler sets the Epoch time to Jan 1st, 2000. We can
+        // increase the offset to Jan 1st, 1970 if folks want that format
+        t += 946684800;
+    }
+    return t;
+
 }
 
 // Returns local time in UNIX Epoch time format

--- a/src/SparkFun_RV8803.h
+++ b/src/SparkFun_RV8803.h
@@ -27,7 +27,7 @@ Distributed as-is; no warranty is given.
 #endif
 
 #include <Wire.h>
-#include <Time.h>
+#include <time.h>
 
 //The 7-bit I2C address of the RV8803
 #define RV8803_ADDR							0x32

--- a/src/SparkFun_RV8803.h
+++ b/src/SparkFun_RV8803.h
@@ -27,6 +27,7 @@ Distributed as-is; no warranty is given.
 #endif
 
 #include <Wire.h>
+#include <Time.h>
 
 //The 7-bit I2C address of the RV8803
 #define RV8803_ADDR							0x32

--- a/src/SparkFun_RV8803.h
+++ b/src/SparkFun_RV8803.h
@@ -265,6 +265,12 @@ public:
 	bool readMultipleRegisters(uint8_t addr, uint8_t * dest, uint8_t len);
 	bool writeMultipleRegisters(uint8_t addr, uint8_t * values, uint8_t len);
 
+	// When converting from a UTC based struct tm to a time_t value, you would normally use a utc
+	// version of mktime - timegm(), but we don't have that on most micro controllers - so use 
+	// the following. 
+	static time_t sub_mkgmt(struct tm *tm);
+	time_t _timegm(struct tm *tm);
+
   private:
 	uint8_t _time[TIME_ARRAY_LENGTH];
 	bool _isTwelveHour = true;

--- a/src/SparkFun_RV8803.h
+++ b/src/SparkFun_RV8803.h
@@ -269,8 +269,8 @@ public:
 	// When converting from a UTC based struct tm to a time_t value, you would normally use a utc
 	// version of mktime - timegm(), but we don't have that on most micro controllers - so use 
 	// the following. 
-	static time_t sub_mkgmt(struct tm *tm);
-	time_t _timegm(struct tm *tm);
+	static time_t sub_mkgmt(struct tm *tm, bool use1970sEpoch);
+	time_t _timegm(struct tm *tm, bool use1970sEpoch);
 
   private:
 	uint8_t _time[TIME_ARRAY_LENGTH];


### PR DESCRIPTION
I've fixed the getEpoch() issue by implementing a mktime() call that doesn't use the local timezone setting.

@SFE-Brudnerd - you were close in the issue you filed in flux! 

The root cause was that getEpoch(), was calling getLocalEpoch(), that took into account the timezone set at the system level. This offset was never corrected in getEpoch(). The correct solution is for getEpoch() to calculate the ticks not taking the timezone into account (The RTC is storing values as epoch() - UTC. )   

On a normal linux/unix/posix system, you'd use the call timegm(), but micro controllers/esp32 don't implement this - but I fond a version and added it.   Using this fixes the issue.  calling setEpoch() and the calling getEpoch() returns the expect values! 

