### PR TITLE
Update SparkFun_RV8803.cpp

### DIFF
--- a/src/SparkFun_RV8803.cpp
+++ b/src/SparkFun_RV8803.cpp
@@ -472,7 +472,7 @@ uint32_t RV8803::getEpoch(bool use1970sEpoch)
 
     struct tm tm;
 
-    tm.tm_isdst = -1;
+    tm.tm_isdst = 0;
     tm.tm_yday = 0;
     tm.tm_wday = 0;
     tm.tm_year = BCDtoDEC(_time[TIME_YEAR]) + 100;


### PR DESCRIPTION
Set getEpoch to ignore timezone, always return epoch for gmt. This makes it possible that when we do a getEpoch we recover the same value added by setEpoch regardless of the configured time zone.